### PR TITLE
update: ensure knowledge_base *.csv are installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,14 @@ dev = [
     "pytest-asyncio",
 ]
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"recommender.knowledge_base" = ["*.csv"]
 
 [project.urls]
 Homepage = "https://github.com/foundation-model-stack/tuning-config-recommender"


### PR DESCRIPTION
PR ensure knowledge_base *.csv are installed.

```
python fms-sculpt.py --preview tuning.sft_trainer \
--model_name_or_path ibm-granite/granite-4.0-h-350m \
--training_data_path tatsu-lab/alpaca \
--tuning_strategy full
```
 and following are the screenshots of updated pyproject.yaml of `fms-hf-tuning` to use fms-adapter branch for testing:
 
 
<img width="1186" height="371" alt="image" src="https://github.com/user-attachments/assets/4e973191-b0c1-4cb6-9f7f-5ddd0b83a503" />
 
<img width="1367" height="619" alt="image" src="https://github.com/user-attachments/assets/b7c0c8b0-5f3d-4c5f-8cbf-4e60fdad044c" />

This PR is used to address this issue and its fix in a structured manner to avoid multiple commits in a single branch