### PR TITLE
fix: remove multiple bugs with QA dataset configs

### DIFF
--- a/src/recommender/actions/data.py
+++ b/src/recommender/actions/data.py
@@ -98,12 +98,11 @@ class ApplyQAFormat(ApplyDataFormat):
     def _get_values_for_given_datapath(self, dataset_path: str):
         # TODO: Actions should made aware of the existing user changes
         # right now they work in replace-everything-first approach
-        jinja_template = "### Input: {{}} \\\n\\\n### Response: {{}}"
         input_text, response_text = determine_input_and_response_text(dataset_path)
-        template = jinja_template.format(input_text, response_text)
+        template = f"\"### Input: {{{{ {input_text} }}}}\\n\\n### Response: {{{{ {response_text} }}}}\""
         formatted_text_column_name = "formatted_qa_data"
         dataset_text_field = "formatted_qa_data"
-        response_template = "\\\n### Response:"
+        response_template = f"\\n### Response:"
         return {
             "template": template,
             "input_text": input_text,
@@ -152,7 +151,7 @@ class ApplyQAFormat(ApplyDataFormat):
 
         for dataset in ir.data_preprocessor["datasets"]:
             values_to_set = self._get_values_for_given_dataset(dataset)
-            ir.train_config = ir.train_config.update(
+            ir.train_config.update(
                 {
                     "dataset_text_field": values_to_set["dataset_text_field"],
                     "response_template": values_to_set["response_template"],

--- a/src/recommender/utils/data_config.py
+++ b/src/recommender/utils/data_config.py
@@ -116,13 +116,13 @@ def determine_input_and_response_text(training_data_path: str) -> dict:
     input_col = "input"
     output_col = "output"
 
-    for col in COMMON_INPUT_KEYS:
-        if any(key in col.lower() for key in columns):
+    for col in columns:
+        if any(key in col.lower() for key in COMMON_INPUT_KEYS):
             input_col = col
             break
 
-    for col in COMMON_RESPONSE_KEYS:
-        if any(key in col.lower() for key in columns):
+    for col in columns:
+        if any(key in col.lower() for key in COMMON_RESPONSE_KEYS):
             output_col = col
             break
 


### PR DESCRIPTION
PR fixes a few bugs with QA Dataset:

1. ### Incorrect Template generation
`{{}}` placeholders, were not valid Python .format() tokens and prevented the input/output field names from being inserted into the Jinja template, I had used proper Jinja brace escaping with `{{{{ }}}}`
<img width="2750" height="1236" alt="image" src="https://github.com/user-attachments/assets/689b89cb-740a-4b1a-91f2-c9010d63c7d8" />

2. ### lack of `dataset_text_field` value in generated train_config
<img width="1155" height="497" alt="image" src="https://github.com/user-attachments/assets/dc0bab77-d7f8-4974-b12f-6c9a9c3d12f8" />

This is due to the line 
```
ir.train_config = ir.train_config.update(
```
as dict.update is inplace and returns None..
  
3. ### Bug with column-matching logic for input/output fields
  We had the logic reversed rather than checking whether common patterns appeared inside the dataset’s column names, the code was checking whether the dataset column names appeared inside the common patterns and we get incorrect matches.
 
<img width="986" height="101" alt="image" src="https://github.com/user-attachments/assets/16cd153d-9ecd-4371-84f4-d0d95223bbb3" />

 
4. ### Minor Formatting of `response_template` and `template` fields with literals
<img width="299" height="146" alt="image" src="https://github.com/user-attachments/assets/e58a0baf-9d8d-40e0-b591-e637e0c2877f" />

