### PR TITLE
fix: remove multiple bugs with Chat dataset configs

### DIFF
--- a/src/recommender/utils/data_config.py
+++ b/src/recommender/utils/data_config.py
@@ -129,10 +129,8 @@ def determine_input_and_response_text(training_data_path: str) -> dict:
     return input_col, output_col
 
 
-def has_any_key_containing(example: dict, key_substrings: list[str]) -> bool:
-    """Check if any key in example contains any of the substrings in key_substrings"""
-    example_keys_lower = [k.lower() for k in example.keys()]
-    for key in key_substrings:
-        if key in example_keys_lower:
-            return True
-    return False
+def has_any_key_containing(example, key_substrings):
+    return any(
+        any(sub in key.lower() for sub in key_substrings)
+        for key in example.keys()
+    )

--- a/src/recommender/utils/data_processing.py
+++ b/src/recommender/utils/data_processing.py
@@ -42,6 +42,19 @@ def maybe_is_a_hf_dataset_id(training_data_path: str) -> bool:
     return len(training_data_path.split("/")) == 2
 
 
+def pick_train_split(dataset) -> str:
+    """Choose a split containing 'train' substring"""
+    splits = list(dataset.keys())
+    if not splits:
+        raise ValueError("Dataset has no splits.")
+    # substring match with 'train'
+    train_like = [s for s in splits if "train" in s.lower()]
+    if train_like:
+        return train_like[0]
+
+    return splits[0]
+
+
 def load_training_data(training_data_path: str) -> dict:
     """Load and validate training data based on training_data_path."""
     _dataset_cache = {}
@@ -55,7 +68,8 @@ def load_training_data(training_data_path: str) -> dict:
     elif os.path.isdir(training_data_path) or maybe_is_a_hf_dataset_id:
         try:
             dataset = load_dataset(training_data_path)
-            data = [dict(example) for example in dataset["train"]]
+            split=pick_train_split(dataset)
+            data = [dict(example) for example in dataset[split]]
             return data
         except Exception as e:
             raise ValueError(f"Error loading dataset from folder or hf id: {e}")


### PR DESCRIPTION
PR fixes a few bugs while working with Chat Dataset:

1. ### missing positional arguments:
<img width="2486" height="672" alt="image" src="https://github.com/user-attachments/assets/b8d2d89a-5829-4d0f-acda-073b56b7a53e" />

2. ### incorrect if statement `if chat_key in data:` where data is a list obj rather than column names
<img width="2424" height="814" alt="image" src="https://github.com/user-attachments/assets/e02727c4-9d23-487d-9847-c9eb65c4af86" />

3. ### hardcoding "train" split
<img width="2402" height="1384" alt="image" src="https://github.com/user-attachments/assets/f4659613-10a1-4e4d-86c6-1bea1771e8aa" />
 the new pick train split function searches for splits with train substring for better handling.. as not all splits will be named "train"
Ex: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k has split names "train_sft"

